### PR TITLE
check if second item is True to identify connected minions

### DIFF
--- a/check_salt.pl
+++ b/check_salt.pl
@@ -93,7 +93,8 @@ while (scalar(@lines) > 0){
         }
         chomp(my $reachable = shift(@lines)); # the second item is True/False
         # Make a list of unreachable minions
-        if ($reachable =~ "Not connected"){
+        $reachable =~ s/^\s+|\s+$//g;
+        if ($reachable ne "True"){
                 if (!$unreachable){ # if the string is empty
                         chop($unreachable = $minion);
                 } else { # concatenate to existing string


### PR DESCRIPTION
We have the issue, that we are getting the following lines in the output, which are not recognized as unreachable nodes.

    Minion did not return. [No response]

Instead of checking the reachable line to a certain string if it is not reachable, i would prefer to check if the line is True to identify connected minions, otherwise unconnected.